### PR TITLE
Remove potential panic

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -42,7 +42,7 @@ func StartServer(port string) {
 
 			handler, err := s.Handler.Router.Handle(req.RequestLine.Method, req.RequestLine.RequestTarget)
 			if err != nil {
-				fmt.Println(err)
+				log.Fatal(err)
 			}
 			handler(c, req)
 


### PR DESCRIPTION
You are logging the error here but still calling the returned `handler` regardless of the value of `handler`, which can be nil, which would cause a panic.

Additionally, calling `log.Fatal()` in this function won't call deferred functions before exiting. You are better off changing `StartServer` to return an error and return an error instead of `log.Fatal()`. In the for-loop though, you can log and then use `continue` so you log, but just move on to the next request. 

Thanks!